### PR TITLE
RJTT ACA 2.1.0

### DIFF
--- a/final/AS/JPN/RJTT.txt
+++ b/final/AS/JPN/RJTT.txt
@@ -1587,7 +1587,7 @@ runway = rwy3
 beacon = ARLON
 
 #ILS Z RWY 34R from ARLON
-route2 = 
+route1 = 
 	6
 #ARLON >4000
 	N35.15.25.28, E139.58.59.79
@@ -1623,6 +1623,7 @@ route3 =
 	19.4, 5000, 200
 #APOLO >5000
 
+
 #Y71 XAC XAC1A
 [approach7]
 runway = rwy1
@@ -1649,6 +1650,7 @@ route1 =
 	19.4, 5000, 200
 #APOLO >5000
 
+
 [approach8]
 runway = rwy1
 beacon = ACORN
@@ -1671,6 +1673,7 @@ route1 =
 #ARLON >5000
 	19.4, 5000, 200
 #APOLO >5000
+
 
 #Y21 AKSEL AKSEL1A
 [approach9]
@@ -1696,6 +1699,7 @@ route1 =
 	19.4, 5000, 200
 #APOLO >5000
 
+
 #Y21 AKSEL AKSEL1A
 [approach10]
 runway = rwy1
@@ -1717,6 +1721,7 @@ route1 =
 #ARLON >5000
 	19.4, 5000, 200
 #APOLO >5000
+
 
 #Y824 AROSA AROSA1A
 [approach11]
@@ -1742,6 +1747,7 @@ route1 =
 #ARLON >5000
 	19.4, 5000, 200
 #APOLO >5000
+
 
 #Y875 AROSA AROSA1A
 [approach12]
@@ -1769,6 +1775,7 @@ route1 =
 	19.4, 5000, 200
 #APOLO >5000
 
+
 [approach13]
 runway = rwy1
 beacon = AVEEY
@@ -1790,6 +1797,7 @@ route1 =
 	19.4, 5000, 200
 #APOLO >5000
 
+
 [approach14]
 runway = rwy1
 beacon = WEDGE
@@ -1800,6 +1808,7 @@ route1 =
 #ARLON >5000
 	19.4, 5000, 200
 #APOLO >5000
+
 
 #Y10 GODIN GODIN1C
 [approach15]
@@ -1832,6 +1841,7 @@ route1 =
 #CAMEL =4000
 	17.6, 4000, 200
 #CACAO
+
 
 #Y807 POLIX POLIX1C
 [approach16]
@@ -1871,6 +1881,7 @@ route2 =
 	17.6, 4000, 200
 #CACAO
 
+
 [approach17]
 runway = rwy3
 beacon = RUSDA, N35.56.47.49, E140.57.29.87
@@ -1906,6 +1917,7 @@ route2 =
 	17.6, 4000, 200
 #CACAO
 
+
 [approach18]
 runway = rwy3
 beacon = ESKEN, N36.05.01.09, E140.41.22.76
@@ -1939,6 +1951,7 @@ route2 =
 	17.6, 4000, 200
 #CACAO
 
+
 [approach19]
 runway = rwy3
 beacon = POLIX
@@ -1970,6 +1983,7 @@ route2 =
 	17.6, 4000, 200
 #CACAO
 
+
 [approach20]
 runway = rwy3
 beacon = CHIPS, N36.12.47.70, E140.14.36.89
@@ -1999,6 +2013,7 @@ route1 =
 	17.6, 4000, 200
 #CACAO
 
+
 [approach21]
 runway = rwy3
 beacon = COLOR
@@ -2026,6 +2041,7 @@ route2 =
 	17.6, 4000, 200
 #CACAO
 
+
 [approach22]
 runway = rwy3
 beacon = COPSE, N35.46.58.79, E140.12.05.38
@@ -2050,6 +2066,7 @@ route2 =
 #CAMEL =4000
 	17.6, 4000, 200
 #CACAO
+
 
 [approach23]
 runway = rwy3
@@ -3065,7 +3082,7 @@ route1 =
 
 [approach64]
 runway = rwy4
-beacon = POLIX, N36.05.01.09, E140.41.22.76
+beacon = POLIX
 route1 = 
 	310
 #POLIX =15000
@@ -6308,11 +6325,12 @@ route1 =
 	N35.27.57.71, E140.40.15.22
 #GIINA
 	15.4, 4000, 220
+#COSMO
 
 
 #Y81 RUTAS RUTAST/Y87 BAFFY Y81 RUTAS RUTAST
 [approach149]
-runway = rwy5
+runway = rwy6
 beacon = BAFFY
 
 route1 = 
@@ -6338,13 +6356,13 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 [approach150]
-runway = rwy5
+runway = rwy6
 beacon = MAMAS, N34.27.33.98, E140.08.57.99
 
 route1 = 
@@ -6368,13 +6386,13 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 [approach151]
-runway = rwy5
+runway = rwy6
 beacon = RUTAS
 
 route1 = 
@@ -6396,13 +6414,13 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 [approach152]
-runway = rwy5
+runway = rwy6
 beacon = VENUS
 
 route1 = 
@@ -6422,13 +6440,13 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 [approach153]
-runway = rwy5
+runway = rwy6
 beacon = JARED, N35.10.24.76, E140.52.15.40
 
 route1 = 
@@ -6446,15 +6464,15 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 
 #Y30/R211 SWAMP SWAMPT
 [approach154]
-runway = rwy5
+runway = rwy6
 beacon = SWAMP
 
 route1 = 
@@ -6482,14 +6500,14 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 
 [approach155]
-runway = rwy5
+runway = rwy6
 beacon = VIXEN, N36.13.35.93, E140.39.47.14
 
 route1 = 
@@ -6515,14 +6533,14 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 
 [approach156]
-runway = rwy5
+runway = rwy6
 beacon = PLEIA
 
 route1 = 
@@ -6546,14 +6564,14 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 
 [approach157]
-runway = rwy5
+runway = rwy6
 beacon = KARMA
 
 route1 = 
@@ -6575,14 +6593,14 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 
 [approach158]
-runway = rwy5
+runway = rwy6
 beacon = DREAM, N35.38.53.25, E141.00.23.88
 
 route1 = 
@@ -6602,14 +6620,14 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 
 [approach159]
-runway = rwy5
+runway = rwy6
 beacon = MCGEE, N35.32.29.00, E141.03.11.84
 
 route1 = 
@@ -6627,15 +6645,15 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 
 #Y809 SUPOK SUPOKT
 [approach160]
-runway = rwy5
+runway = rwy6
 beacon = SUPOK
 
 route1 = 
@@ -6657,14 +6675,14 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 
 [approach161]
-runway = rwy5
+runway = rwy6
 beacon = SOFIA, N35.33.00.12, E141.11.49.94
 
 route1 = 
@@ -6684,15 +6702,15 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 
 #Y813 LUBLA LUBLAT
 [approach162]
-runway = rwy5
+runway = rwy6
 beacon = LUBLA
 
 route1 = 
@@ -6714,15 +6732,15 @@ route1 =
 #PEAKS =6000
 	N35.25.07.15, E140.43.52.65, 6000
 #TYLER
-	N35.26.50.48, E140.38.07.77, 4000
-#GIINA
-	15.4, 4000, 220
-#COSMO
+	N35.26.50.48, E140.38.07.77
+#TEMIS
+	17.5, 5000, 220
+#LAPIS
 
 
 #Y81 RUTAS RUTASE/Y87 BAFFY Y81 RUTAS RUTASE
 [approach163]
-runway = rwy6
+runway = rwy5
 beacon = BAFFY
 
 route1 = 
@@ -6744,16 +6762,16 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 [approach164]
-runway = rwy6
+runway = rwy5
 beacon = MAMAS, N34.27.33.98, E140.08.57.99
 
 route1 = 
@@ -6773,16 +6791,16 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 [approach165]
-runway = rwy6
+runway = rwy5
 beacon = RUTAS
 
 route1 = 
@@ -6800,16 +6818,16 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 [approach166]
-runway = rwy6
+runway = rwy5
 beacon = JITAN, N34.49.14.19, E140.53.49.27
 
 route1 = 
@@ -6825,16 +6843,16 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 [approach167]
-runway = rwy6
+runway = rwy5
 beacon = AQUOS
 
 route1 = 
@@ -6848,16 +6866,16 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 [approach168]
-runway = rwy6
+runway = rwy5
 beacon = SIGMA, N35.24.25.49, E141.13.18.26
 
 route1 = 
@@ -6869,17 +6887,17 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 #Y30/R211 SWAMP SWAMPE
 [approach169]
-runway = rwy6
+runway = rwy5
 beacon = SWAMP
 
 route1 = 
@@ -6899,17 +6917,17 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 #Y30/R211 SWAMP SWAMPE
 [approach170]
-runway = rwy6
+runway = rwy5
 beacon = VIXEN, N36.13.35.93, E140.39.47.14
 
 route1 = 
@@ -6927,17 +6945,17 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 #Y30/R211 SWAMP SWAMPE
 [approach171]
-runway = rwy6
+runway = rwy5
 beacon = PLEIA
 
 route1 = 
@@ -6953,17 +6971,17 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 #Y30/R211 SWAMP SWAMPE
 [approach172]
-runway = rwy6
+runway = rwy5
 beacon = MIFFY, N36.02.32.05, E140.49.59.52
 
 route1 = 
@@ -6977,17 +6995,17 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 #Y30/R211 SWAMP SWAMPE
 [approach173]
-runway = rwy6
+runway = rwy5
 beacon = KARMA
 
 route1 = 
@@ -6999,17 +7017,17 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 #Y809 SUPOK RUTASE
 [approach174]
-runway = rwy6
+runway = rwy5
 beacon = SUPOK
 
 route1 = 
@@ -7023,16 +7041,16 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 [approach175]
-runway = rwy6
+runway = rwy5
 beacon = PLOKY, N35.45.28.26, E141.04.02.29
 
 route1 = 
@@ -7044,16 +7062,16 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 [approach176]
-runway = rwy6
+runway = rwy5
 beacon = UNARI, N35.45.13.78, E140.57.37.07
 
 route1 = 
@@ -7063,17 +7081,17 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 #Y813 LUBLA LUBLAE
 [approach177]
-runway = rwy6
+runway = rwy5
 beacon = LUBLA
 
 route1 = 
@@ -7085,16 +7103,16 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 [approach178]
-runway = rwy6
+runway = rwy5
 beacon = TORCH, N35.24.25.49, E141.13.18.26
 
 route1 = 
@@ -7104,16 +7122,16 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
-#TEMIS
-	17.5, 5000, 220
-#LAPIS
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
 
 
 [approach179]
-runway = rwy6
+runway = rwy5
 beacon = CORGI
 
 route1 = 
@@ -7121,15 +7139,29 @@ route1 =
 #CORGI
 	N35.38.29.77, E140.51.38.90
 #ELGAR
-	N35.31.29.20, E140.45.27.39
-#FIONA
-	N35.28.45.68, E140.41.25.95
+	N35.31.29.20, E140.45.27.39, 4000
+#HARPS
+	N35.27.57.71, E140.40.15.22
+#GIINA
+	15.4, 4000, 220
+#COSMO
+
+
+[approach180]
+runway = rwy6
+beacon = PEAKS
+route1 = 
+	330
+#PEAKS =6000
+	N35.25.07.15, E140.43.52.65, 6000
+#TYLER
+	N35.26.50.48, E140.38.07.77
 #TEMIS
 	17.5, 5000, 220
 #LAPIS
 
 
-[approach180]
+[approach181]
 runway = rwy5
 beacon = PEAKS
 route1 = 
@@ -7144,7 +7176,7 @@ route1 =
 
 
 #ILS Z RWY 16R
-[approach181]
+[approach182]
 runway = rwy5, rev
 beacon = KOALA, N35.59.04.42, E140.12.57.24
 
@@ -7178,7 +7210,7 @@ route2 =
 
 
 #ILS Z RWY 16L
-[approach182]
+[approach183]
 runway = rwy6, rev
 beacon = METIS, N35.59.45.62, E140.14.23.01
 
@@ -7209,7 +7241,7 @@ route2 =
 #CYGNY
 
 
-[approach183]
+[approach184]
 runway = rwy5, rev
 beacon = GEMIN
 
@@ -7228,7 +7260,7 @@ route1 =
 #GREBE
 
 
-[approach184]
+[approach185]
 runway = rwy6, rev
 beacon = GEMIN
 
@@ -7245,7 +7277,7 @@ route1 =
 #CYGNY
 
 
-[approach185]
+[approach186]
 runway = rwy5, rev
 beacon = NORMA
 
@@ -7264,7 +7296,7 @@ route1 =
 #GREBE
 
 
-[approach186]
+[approach187]
 runway = rwy6, rev
 beacon = NORMA
 
@@ -7284,8 +7316,8 @@ route1 =
 
 
 #Y81 RUTAS RUTASG/Y87 BAFFY Y81 RUTASG
-[approach187]
-runway = rwy5, rev
+[approach188]
+runway = rwy6, rev
 beacon = BAFFY
 
 route1 = 
@@ -7310,21 +7342,19 @@ route1 =
 	N35.58.56.27, E140.52.34.61, 10000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
-[approach188]
-runway = rwy5, rev
+[approach189]
+runway = rwy6, rev
 beacon = MAMAS, N34.27.33.98, E140.08.57.99
 
 route1 = 
@@ -7347,21 +7377,19 @@ route1 =
 	N35.58.56.27, E140.52.34.61, 10000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
-[approach189]
-runway = rwy5, rev
+[approach190]
+runway = rwy6, rev
 beacon = RUTAS
 
 route1 = 
@@ -7382,21 +7410,19 @@ route1 =
 	N35.58.56.27, E140.52.34.61, 10000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
-[approach190]
-runway = rwy5, rev
+[approach191]
+runway = rwy6, rev
 beacon = VENUS
 
 route1 = 
@@ -7415,21 +7441,19 @@ route1 =
 	N35.58.56.27, E140.52.34.61, 10000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
-[approach191]
-runway = rwy5, rev
+[approach192]
+runway = rwy6, rev
 beacon = COPEN
 
 route1 = 
@@ -7446,21 +7470,19 @@ route1 =
 	N35.58.56.27, E140.52.34.61, 10000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
-[approach192]
-runway = rwy5, rev
+[approach193]
+runway = rwy6, rev
 beacon = BOOTH, N35.40.23.60, E140.51.20.47
 
 route1 = 
@@ -7475,22 +7497,20 @@ route1 =
 	N35.58.56.27, E140.52.34.61, 10000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
 #Y30/R211 SWAMP SWAMPG
-[approach193]
-runway = rwy5, rev
+[approach194]
+runway = rwy6, rev
 beacon = SWAMP
 
 route1 = 
@@ -7511,21 +7531,19 @@ route1 =
 	N35.39.42.43, E140.52.23.89, 9000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
-[approach194]
-runway = rwy5, rev
+[approach195]
+runway = rwy6, rev
 beacon = VIXEN, N36.13.35.93, E140.39.47.14
 
 route1 = 
@@ -7544,21 +7562,19 @@ route1 =
 	N35.39.42.43, E140.52.23.89, 9000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
-[approach195]
-runway = rwy5, rev
+[approach196]
+runway = rwy6, rev
 beacon = PLEIA
 
 route1 = 
@@ -7575,21 +7591,19 @@ route1 =
 	N35.39.42.43, E140.52.23.89, 9000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
-[approach196]
-runway = rwy5, rev
+[approach197]
+runway = rwy6, rev
 beacon = BETEL, N35.59.31.59, E140.53.43.40
 
 route1 = 
@@ -7604,21 +7618,19 @@ route1 =
 	N35.39.42.43, E140.52.23.89, 9000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
-[approach197]
-runway = rwy5, rev
+[approach198]
+runway = rwy6, rev
 beacon = SUPOK
 
 route1 = 
@@ -7639,21 +7651,19 @@ route1 =
 	N36.00.06.89, E140.54.52.20, 8000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
-[approach198]
-runway = rwy5, rev
+[approach199]
+runway = rwy6, rev
 beacon = REGZA, N35.39.25.80, E141.08.09.06
 
 route1 = 
@@ -7670,21 +7680,19 @@ route1 =
 	N36.00.06.89, E140.54.52.20, 8000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
-[approach199]
-runway = rwy5, rev
+[approach200]
+runway = rwy6, rev
 beacon = VOGUE, N35.39.27.63, E140.59.08.40
 
 route1 = 
@@ -7699,21 +7707,19 @@ route1 =
 	N36.00.06.89, E140.54.52.20, 8000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
-[approach200]
-runway = rwy5, rev
+[approach201]
+runway = rwy6, rev
 beacon = LUBLA
 
 route1 = 
@@ -7732,22 +7738,20 @@ route1 =
 	N36.00.06.89, E140.54.52.20, 8000, 210
 #CASIO =6000
 	N35.50.21.35, E140.35.56.06, 6000
-#GEMIN >6000
+#GEMIN >4000
 	N35.57.38.61, E140.24.50.74
-#ACELA >6000 <7000
-	N36.07.12.79, E140.19.19.55, 7000
-#PIXUS >4000
-	N36.07.08.49, E140.10.35.18
-#BROOK
-	N36.02.14.16, E140.10.39.12
-#KOALA >4000
-	14.6, 4000, 220
-#GREBE
+#MARCH =3000 185
+	N36.02.11.30, E140.17.18.80, 3000, 185
+#LARKS
+	N36.02.09.87, E140.14.21.20
+#METIS =3000
+	14.6, 3000, 185
+#CYGNY
 
 
 #Y81 RUTAS RUTASG/Y87 BAFFY Y81 RUTASG
-[approach201]
-runway = rwy6, rev
+[approach202]
+runway = rwy5, rev
 beacon = BAFFY
 
 route1 = 
@@ -7766,19 +7770,19 @@ route1 =
 	N35.45.51.02, E141.01.11.97
 #NORMA >6000
 	N35.59.00.83, E140.32.53.97
-#LUNAR >4000 <5000
-	N35.59.50.75, E140.28.49.98, 5000
-#MARCH =3000 185
-	N36.02.11.30, E140.17.18.80, 3000, 185
-#LARKS
-	N36.02.09.87, E140.14.21.20
-#METIS =3000
-	14.6, 3000, 185
-#CYGNY
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
 
 
-[approach202]
-runway = rwy6, rev
+[approach203]
+runway = rwy5, rev
 beacon = MAMAS, N34.27.33.98, E140.08.57.99
 
 route1 = 
@@ -7795,19 +7799,19 @@ route1 =
 	N35.45.51.02, E141.01.11.97
 #NORMA >6000
 	N35.59.00.83, E140.32.53.97
-#LUNAR >4000 <5000
-	N35.59.50.75, E140.28.49.98, 5000
-#MARCH =3000 185
-	N36.02.11.30, E140.17.18.80, 3000, 185
-#LARKS
-	N36.02.09.87, E140.14.21.20
-#METIS =3000
-	14.6, 3000, 185
-#CYGNY
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
 
 
-[approach203]
-runway = rwy6, rev
+[approach204]
+runway = rwy5, rev
 beacon = RUTAS
 
 route1 = 
@@ -7822,19 +7826,19 @@ route1 =
 	N35.45.51.02, E141.01.11.97
 #NORMA >6000
 	N35.59.00.83, E140.32.53.97
-#LUNAR >4000 <5000
-	N35.59.50.75, E140.28.49.98, 5000
-#MARCH =3000 185
-	N36.02.11.30, E140.17.18.80, 3000, 185
-#LARKS
-	N36.02.09.87, E140.14.21.20
-#METIS =3000
-	14.6, 3000, 185
-#CYGNY
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
 
 
-[approach204]
-runway = rwy6, rev
+[approach205]
+runway = rwy5, rev
 beacon = VENUS
 
 route1 = 
@@ -7847,19 +7851,19 @@ route1 =
 	N35.45.51.02, E141.01.11.97
 #NORMA >6000
 	N35.59.00.83, E140.32.53.97
-#LUNAR >4000 <5000
-	N35.59.50.75, E140.28.49.98, 5000
-#MARCH =3000 185
-	N36.02.11.30, E140.17.18.80, 3000, 185
-#LARKS
-	N36.02.09.87, E140.14.21.20
-#METIS =3000
-	14.6, 3000, 185
-#CYGNY
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
 
 
-[approach205]
-runway = rwy6, rev
+[approach206]
+runway = rwy5, rev
 beacon = GAUDI
 
 route1 = 
@@ -7870,19 +7874,19 @@ route1 =
 	N35.45.51.02, E141.01.11.97
 #NORMA >6000
 	N35.59.00.83, E140.32.53.97
-#LUNAR >4000 <5000
-	N35.59.50.75, E140.28.49.98, 5000
-#MARCH =3000 185
-	N36.02.11.30, E140.17.18.80, 3000, 185
-#LARKS
-	N36.02.09.87, E140.14.21.20
-#METIS =3000
-	14.6, 3000, 185
-#CYGNY
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
 
 
-[approach206]
-runway = rwy6, rev
+[approach207]
+runway = rwy5, rev
 beacon = SWAMP
 
 route1 = 
@@ -7903,19 +7907,19 @@ route1 =
 	N35.45.51.02, E141.01.11.97
 #NORMA >6000
 	N35.59.00.83, E140.32.53.97
-#LUNAR >4000 <5000
-	N35.59.50.75, E140.28.49.98, 5000
-#MARCH =3000 185
-	N36.02.11.30, E140.17.18.80, 3000, 185
-#LARKS
-	N36.02.09.87, E140.14.21.20
-#METIS =3000
-	14.6, 3000, 185
-#CYGNY
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
 
 
-[approach207]
-runway = rwy6, rev
+[approach208]
+runway = rwy5, rev
 beacon = VIXEN, N36.13.35.93, E140.39.47.14
 
 route1 = 
@@ -7934,19 +7938,19 @@ route1 =
 	N35.45.51.02, E141.01.11.97
 #NORMA >6000
 	N35.59.00.83, E140.32.53.97
-#LUNAR >4000 <5000
-	N35.59.50.75, E140.28.49.98, 5000
-#MARCH =3000 185
-	N36.02.11.30, E140.17.18.80, 3000, 185
-#LARKS
-	N36.02.09.87, E140.14.21.20
-#METIS =3000
-	14.6, 3000, 185
-#CYGNY
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
 
 
-[approach208]
-runway = rwy6, rev
+[approach209]
+runway = rwy5, rev
 beacon = PLEIA
 
 route1 = 
@@ -7963,19 +7967,19 @@ route1 =
 	N35.45.51.02, E141.01.11.97
 #NORMA >6000
 	N35.59.00.83, E140.32.53.97
-#LUNAR >4000 <5000
-	N35.59.50.75, E140.28.49.98, 5000
-#MARCH =3000 185
-	N36.02.11.30, E140.17.18.80, 3000, 185
-#LARKS
-	N36.02.09.87, E140.14.21.20
-#METIS =3000
-	14.6, 3000, 185
-#CYGNY
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
 
 
-[approach209]
-runway = rwy6, rev
+[approach210]
+runway = rwy5, rev
 beacon = SUPOK
 
 route1 = 
@@ -7988,19 +7992,19 @@ route1 =
 	N35.45.51.02, E141.01.11.97
 #NORMA >6000
 	N35.59.00.83, E140.32.53.97
-#LUNAR >4000 <5000
-	N35.59.50.75, E140.28.49.98, 5000
-#MARCH =3000 185
-	N36.02.11.30, E140.17.18.80, 3000, 185
-#LARKS
-	N36.02.09.87, E140.14.21.20
-#METIS =3000
-	14.6, 3000, 185
-#CYGNY
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
 
 
-[approach210]
-runway = rwy6, rev
+[approach211]
+runway = rwy5, rev
 beacon = LUBLA
 
 route1 = 
@@ -8013,19 +8017,19 @@ route1 =
 	N35.45.51.02, E141.01.11.97
 #NORMA >6000
 	N35.59.00.83, E140.32.53.97
-#LUNAR >4000 <5000
-	N35.59.50.75, E140.28.49.98, 5000
-#MARCH =3000 185
-	N36.02.11.30, E140.17.18.80, 3000, 185
-#LARKS
-	N36.02.09.87, E140.14.21.20
-#METIS =3000
-	14.6, 3000, 185
-#CYGNY
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
 
 
-[approach211]
-runway = rwy6, rev
+[approach212]
+runway = rwy5, rev
 beacon = REGZA
 
 route1 = 
@@ -8036,19 +8040,19 @@ route1 =
 	N35.45.51.02, E141.01.11.97
 #NORMA >6000
 	N35.59.00.83, E140.32.53.97
-#LUNAR >4000 <5000
-	N35.59.50.75, E140.28.49.98, 5000
-#MARCH =3000 185
-	N36.02.11.30, E140.17.18.80, 3000, 185
-#LARKS
-	N36.02.09.87, E140.14.21.20
-#METIS =3000
-	14.6, 3000, 185
-#CYGNY
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
 
 
-[approach212]
-runway = rwy6, rev
+[approach213]
+runway = rwy5, rev
 beacon = BARON
 
 route1 = 
@@ -8057,8 +8061,27 @@ route1 =
 	N35.45.51.02, E141.01.11.97
 #NORMA >6000
 	N35.59.00.83, E140.32.53.97
-#LUNAR >4000 <5000
-	N35.59.50.75, E140.28.49.98, 5000
+#ACELA >6000 <7000
+	N36.07.12.79, E140.19.19.55, 7000
+#PIXUS >4000
+	N36.07.08.49, E140.10.35.18
+#BROOK
+	N36.02.14.16, E140.10.39.12
+#KOALA >4000
+	14.6, 4000, 220
+#GREBE
+	
+
+[approach214]
+runway = rwy6, rev
+beacon = CASIO
+
+route1 = 
+	280
+#CASIO =6000
+	N35.50.21.35, E140.35.56.06, 6000
+#GEMIN >4000
+	N35.57.38.61, E140.24.50.74
 #MARCH =3000 185
 	N36.02.11.30, E140.17.18.80, 3000, 185
 #LARKS
@@ -8068,7 +8091,7 @@ route1 =
 #CYGNY
 	
 
-[approach213]
+[approach215]
 runway = rwy5, rev
 beacon = CASIO
 
@@ -8087,6 +8110,8 @@ route1 =
 #KOALA >4000
 	14.6, 4000, 220
 #GREBE
+
+
 
 [departure8]
 runway = rwy5
@@ -8873,43 +8898,43 @@ route9 =
 #RJTT departing 34R/05, arriving 34L/34R
 #RJAA departing/arriving 34L/34R
 config1 = 
+	0, rwy1, land
 	0, rwy3, landstart
 	0, rwy4, startrev
-	0, rwy1, land
-	0, rwy5, landstart
 	0, rwy6, landstart
+	0, rwy5, landstart
 
 #South wind operation
 #RJTT departing 16L/16R, arriving ILS 22/ILS 23
 #RJAA departing/arriving 16L/16R
 config2 = 
-	0, rwy3, startrev
+	0, rwy2, land
 	0, rwy4, land
 	0, rwy1, startrev
-	0, rwy2, land
-	0, rwy5, landstartrev
+	0, rwy3, startrev
 	0, rwy6, landstartrev
+	0, rwy5, landstartrev
 
 #South wind operation (afternoon)
 #RJTT departing 16R/22, arriving 16L/16R
 #RJAA departing/arriving 16L/16R
 config3 = 
-	0, rwy8, landstartrev
 	0, rwy7, landstartrev
+	0, rwy8, landstartrev
 	0, rwy2, start
-	0, rwy5, landstartrev
 	0, rwy6, landstartrev
+	0, rwy5, landstartrev
 
 #South wind operation VMC
 #RJTT departing 16L/16R, arriving LDA 22/LDA 23
 #RJAA departing/arriving 16L/16R
 config4 = 
 	0, rwy3, startrev
-	0, rwy10, land
 	0, rwy1, startrev
 	0, rwy9, land
-	0, rwy5, landstartrev
+	0, rwy10, land
 	0, rwy6, landstartrev
+	0, rwy5, landstartrev
 
 
 [planetypes]

--- a/final/AS/JPN/RJTT_readme.md
+++ b/final/AS/JPN/RJTT_readme.md
@@ -2,11 +2,13 @@
 
 This is an implementation of the Tokyo ACA (Approach Control Area) for [Endless ATC](https://steamcommunity.com/app/666610) featuring `RJTT` Tokyo International Airport (commonly referred to as Haneda) and `RJAA` Narita International Airport. The airspace ceiling is FL240.
 
-Based upon AIP Japan 2020/10/08. The choice of SIDs and STARs may not be 100% accurate to real life but should be reasonably accurate reflecting daytime IMC conditions. All aircraft are assumed to be RNAV capable; no conventional NAVAID-based SIDs or STARs are implemented unless there is no RNAV alternative.
+Based upon AIP Japan 2020/10/08. The choice of SIDs and STARs may not be 100% accurate to real life but should be reasonably accurate reflecting daytime IMC conditions. All aircraft are assumed to be RNAV capable; no conventional NAVAID-based SIDs or STARs are implemented unless there is no RNAV alternative. Coastline data from naturalearthdata.com.
 
-The Tokyo ACA is a very large terminal area containing two of Japan's largest airports. The traffic that can flow in and out of these two airports can be immense, but the terminal procedures published for these two airports are robust and can provide you the ability to handle the immense deluge of traffic that can pour into the area. Scores of 40 or higher should be possible to maintain with minimal delay vectoring.
+The Tokyo ACA is a very large terminal area containing two of Japan's largest airports. The traffic that can flow in and out of these two airports can be immense, but the terminal procedures published for these two airports are robust and can provide you the ability to handle the immense deluge of traffic that can pour into the area. Most of the controller's work should be sequencing arrivals and monitoring a few key merge points for conflicts. Scores of 40 or higher should be possible to maintain with minimal delay vectoring.
 
 STARs are implemented as approach transitions. To activate an approach, an aircraft must be flying direct to an applicable fix, then the APP button can be activated. Multiple approaches may be available from a fix. Press the APP button again  before issuing the approach clearance (do not long press) will select the next approach available from that fix. If the aircraft is already on an approach from that fix, you will need to cancel the approach clearance first before issuing another approach clearance.
+
+**\*Departures may need to handed off before they reach the boundary of the ACA\***, *as there are cases where the SID exts the ACA before cruise altitude can be reached.*
 
 JSDF-G bases `RJTE` Tateyama and `RJTK` Kisarazu are not represented as it appears traffic should mostly be military helicopters, which are difficult to represent in this game. JSDF-M base `RJTL` Shimofusa is not currently implemented, but may be in a future version.
 `RJTO` Oshima/`RJAN` Niijima are not represented as traffic is either helicopters or traffic to `RJTF` Chofu in `RJTY` Yokota ACA. Unfortunately traffic to `RJTY` is difficult to represent as `RJTT` ACA has airspace on top of most of `RJTY` ACA, meaning that within the game, it is not possible to get planes to "spawn" from the appropriate region.
@@ -23,12 +25,12 @@ Most fixes visible on the map have a defined hold including many fixes along the
 
 Aircraft arrive at 6 points:
 
-- `SPENS` -> `XAC` (west from western Japan, Korea, Northern China)
-- `SELNO` -> `RUNSO` -> `AKSEL` (south west from southwestern Japan, Okinawa, Southeast Asia)
-- `TOPIT` -> `LUTNA` -> `RURER` -> `AROSA` (south from Hachijojima, Indonesia/Australia)
-- `DOLBA` -> `AROSA` (southeast from oceanic, Australia/NZ/Pacific islands, Guam)
-- `TEDIX` -> `GODIN` (north from northern Japan, Russia, Europe, east NA)
-- `LALID` -> `MILIT` -> `RUSDA` -> `ESKEN` -> `POLIX` (east from oceanic, west NA/SA, Hawaii)
+- `SPENS` -`Y71`-> `XAC` (west from western Japan, Korea, Northern China)
+- `SELNO` -`Y21`-> `RUNSO` -`Y21`-> `AKSEL` (south west from southwestern Japan, Okinawa, Southeast Asia)
+- `TOPIT` -`Y875`-> `RURER` -`Y875`-> `AROSA` (south from Hachijojima, Indonesia/Australia)
+- `DOLBA` -`Y824`-> `AROSA` (southeast from oceanic, Australia/NZ/Pacific islands, Guam)
+- `TEDIX` -`Y10`-> `GODIN` (north from northern Japan, Russia, Europe, east NA)
+- `LALID` -`Y807`-> `POLIX` (east from oceanic, west NA/SA, Hawaii)
 
 Aircraft depart via:
 
@@ -66,8 +68,6 @@ A few different configurations are used in real operations; four are available i
 
 	Note that higher arrivals will conflict with lower arrivals when descending from the point merge arc to meet the =8000 restriction at `WEDGE`. Either descend the lower arrival (watch out for further lower arrivals) or prioritize the lower arrival over the higher arrival. Also watch for `AROSA` arrivals conflicting with arrivals to `RJAA`.
 
-	\***Departures to the west/north/south will need to handed off before they reach the boundary of the ACA**, *as they will likely NOT climb out of the ACA.*\*
-
 	Note that the normal runway operation for 34L/34R arrivals (`HIGHW`AY `VISUA`L 34R and ILS X 34L from `KAIHO`) is not possible to implement due to the lack of visual approaches in the game and the fact that aircraft joining the parallel ILS above `RJTK` Kisarazu would conflict as they are at the same altitude. Therefore the approaches depicted are illustrative of IMC conditions necessitating the use of parallel ILS approaches.
 
 	For an extra challenge, try routing ANA/SNJ/ADO/VIP flights to 34R (T2/VIP area) and JAL/SFJ/SKY/international/GA flights to 34L (T1/T3/N area).
@@ -82,8 +82,6 @@ A few different configurations are used in real operations; four are available i
 
 	`STARS` are available using APP mode from `XAC`, `RUNSO`, `AROSA`, `GODIN`, `MILIT`, and many other intermediate points on the STARs. STARs from the southwest implement a point merge system around `SHAFT` (STARs from the northeast are traditional). Aircraft fly an arc around a `SHAFT`, and you can sequence planes by directing planes to proceed direct `SHAFT` and activate APP mode. By default south arrivals fly STARs and approaches to 22, but you can engage APP mode twice to have planes descend under the `SHAFT` arc to `BACON` for 23. Be careful of conflicts with traffic from the north inbound 23.
 
-	\***Departures to the west/north/south will need to handed off before they reach the boundary of the ACA**, *as they will likely NOT climb out of the ACA.*\*
-
 	For an extra challenge, try routing ANA/SNJ/ADO/VIP flights to 23 (T2/VIP area) and JAL/SFJ/SKY/international/GA flights to 22 (T1/T3/N area).
 
 -	Landing 22/23 (LDA), departing 16L/16R
@@ -96,8 +94,6 @@ A few different configurations are used in real operations; four are available i
 
 	`STARS` are available using APP mode from `XAC`, `RUNSO`, `AROSA`, `GODIN`, `MILIT`, and many other intermediate points on the STARs. STARs from the southwest implement a point merge system around `SHAFT` (STARs from the northeast are traditional). Aircraft fly an arc around a `SHAFT`, and you can sequence planes by directing planes to proceed direct `SHAFT` and activate APP mode.  By default south arrivals fly STARs and approaches to 22, but you can engage APP mode twice to have planes descend under the `SHAFT` arc to `BACON` for 23. Be careful of conflicts with traffic from the north inbound 23.
 
-	\***Departures to the west/north/south will need to handed off before they reach the boundary of the ACA**, *as they will likely NOT climb out of the ACA.*\*
-
 	Note that the LDA approaches are represented by a runway located where one would be if the LDA approaches were straight-in ILS approaches; this is the best implementation given limitations of the game, but from an approach control perspective it should be a fairly accurate representation.
 
 	For an extra challenge, try routing ANA/SNJ/ADO/VIP flights to 23 (T2/VIP area) and JAL/SFJ/SKY/international/GA flights to 22 (T1/T3/N area).
@@ -109,8 +105,6 @@ A few different configurations are used in real operations; four are available i
 	Approaches to 16L and 16R are available using APP mode from `SANDY` and `NATTY` respectively.
 
 	`STARS` are available using APP mode from `XAC`, `RUNSO`, `AROSA`, `GODIN`, `MILIT`, and many other intermediate points on the STARs. `STARS` to 16L/16R implement a point merge system around `SHAFT` for 16L and `NEURO` for 16R. Aircraft fly an arc around a point (`SHAFT`/`NEURO`), and you can sequence planes by directing planes to proceed direct `SHAFT`/`NEURO` and activate APP mode. By default south arrivals fly STARs and approaches to 16L, but you can engage APP mode twice to have planes fly over the `SHAFT` arc to join the `NEURO` arc for 16R.
-
-	\***Departures to the west/north/south will need to handed off before they reach the boundary of the ACA**, *as they will likely NOT climb out of the ACA.*\*
 
 	Note that the LDA approaches are represented by a runway located where one would be if the LDA approaches were straight-in ILS approaches; this is the best implementation given limitations of the game, but from an approach control perspective it should be a fairly accurate representation.
 
@@ -126,22 +120,22 @@ Most fixes visible on the map have a defined hold including many fixes along the
 
 Aircraft arrive at 4 points:
 
-- `BAFFY` -> `MAMAS` -> `RUTAS` (southwest from western and southwestern)
-- `VAGLA` -> `LUBLA` (northeast oceanic)
-- `LESPO` -> `SUPOK` (southeast oceanic)
-- `GURIR` -> `SWAMP` (north from north, northwest and northeast)
+- `BAFFY` -`Y81`-> `RUTAS` (southwest from western and southwestern)
+- `VAGLA` -`Y813`-> `LUBLA` (northeast oceanic)
+- `LESPO` -`Y809`-> `SUPOK` (southeast oceanic)
+- `GURIR` -`Y30`-> `SWAMP` (north from north, northwest and northeast)
 
 Aircraft depart via:
 
-- `AGRIS` (northwest)
-- `KIMIN` (north)
-- `GULBO` (northeast oceanic)
-- `BORLO` (east oceanic)
-- `IRNOK` (southsoutheast oceanic)
-- `NORIS` (south oceanic)
-- `SEDRI` (southwest)
-- `MITOP` (west)
-- `TEPEX` (northwest)
+- `AGRIS` (northwest via `TETRA8` departure `AGRIS` transition to `Y37`)
+- `KIMIN` (north via `TETRA8` departure `KIMIN` transition to `Y117`)
+- `GULBO` (northeast oceanic via `GULBO2` departure to `Y808`)
+- `BORLO` (east oceanic via `BORLO2` departure to `Y830`)
+- `IRNOK` (southsoutheast oceanic via `OLVAN2` departure to `Y823`)
+- `NORIS` (south oceanic via `OLVAN2` departure `SAMUS` transition to `Y84`)
+- `SEDRI` (southwest via `PIGOK2` departure to `Y50`)
+- `MITOP` (west via `REDEK2` departure to `Y60`)
+- `TEPEX` (northwest via `TETRA8` departure `ENPAR` transition to `Y16`)
 
 There are two runways:
 
@@ -182,10 +176,9 @@ There are two simple runway configurations:
 - No `RJTT` RNAV 16L/16R due to game limitations (conflicts between parallel arrivals on RNAV track).
 - No fair weather 34L/34R approach usage (no visual approaches, conflict on joining parallel ILS at same altitude)
 - No `RJTO` Oshima/`RJAN` Niijima (not possible to model arrivals from `RJTY` ACA)
-- `SELNO` arrivals can spawn a bit inside the ACA with no warning.
 - Arrival and departure directions can be a bit nonsense (e.g. AHK arriving from the Pacific), unfortunately this is a game limitation.
 - South arrivals to `RJTT` 16L/16R are very close to delayed even strictly following the STAR (game limitation?)
-- `SWAMP`/`SUPOK`/`LUBLA` arrivals prioritize 34R/16L
+- `SWAMP`/`SUPOK`/`LUBLA` arrivals prioritize 34R/16L (ideally they prioritze 16R/34L)
 
 ## Changelog
 

--- a/final/AS/JPN/RJTT_readme.md
+++ b/final/AS/JPN/RJTT_readme.md
@@ -1,18 +1,14 @@
-# RJTT ACA 2.0.3
+# `RJTT` ACA 2.1.0
 
-This is an implementation of the Tokyo ACA (Approach Control Area) for [Endless ATC](https://steamcommunity.com/app/666610) featuring RJTT Tokyo International Airport (commonly referred to as Haneda) and RJAA Narita International Airport.
+This is an implementation of the Tokyo ACA (Approach Control Area) for [Endless ATC](https://steamcommunity.com/app/666610) featuring `RJTT` Tokyo International Airport (commonly referred to as Haneda) and `RJAA` Narita International Airport. The airspace ceiling is FL240.
 
-The Tokyo ACA is a very busy airspace, with two airports handling large amounts of traffic. However, the SIDs and STARs are well defined, and conflicts between flight paths are minimal. The controller's work will mostly be sequencing arrivals and monitoring a few key merge points to maintain separation.
+Based upon AIP Japan 2020/10/08. The choice of SIDs and STARs may not be 100% accurate to real life but should be reasonably accurate reflecting daytime IMC conditions. All aircraft are assumed to be RNAV capable; no conventional NAVAID-based SIDs or STARs are implemented unless there is no RNAV alternative.
 
-Based upon AIP Japan 2020/12/31. The choice of SIDs and STARs may not be 100% accurate to real life but should be reasonably accurate reflecting daytime IMC conditions. All aircraft are assumed to be RNAV capable; no conventional NAVAID-based SIDs or STARs were implemented. Coastline data from naturalearthdata.com.
+The Tokyo ACA is a very large terminal area containing two of Japan's largest airports. The traffic that can flow in and out of these two airports can be immense, but the terminal procedures published for these two airports are robust and can provide you the ability to handle the immense deluge of traffic that can pour into the area. Scores of 40 or higher should be possible to maintain with minimal delay vectoring.
 
-STARs are implemented as approach transitions. To activate an approach, an aircraft must be flying direct to an applicable fix, then the APP button can be activated. Multiple approaches may be available from a fix. Press the APP button again (do not long press) to select the next approach available from that fix. If the aircraft is already on an approach from that fix, you will need to cancel the approach clearance first before issuing another approach clearance.
+STARs are implemented as approach transitions. To activate an approach, an aircraft must be flying direct to an applicable fix, then the APP button can be activated. Multiple approaches may be available from a fix. Press the APP button again  before issuing the approach clearance (do not long press) will select the next approach available from that fix. If the aircraft is already on an approach from that fix, you will need to cancel the approach clearance first before issuing another approach clearance.
 
-Approaches to each runway are generally available from their IF and IAFs. Approaches from the IF will choose a transition appropriate based on the plane's heading to the IF. Approaches to multiple runways may be available from each IAF via the appropriate transitions, click the APP button again to cycle through all choices.
-
-**\*Departures may need to handed off before they reach the boundary of the ACA\***, *as there are cases where the SID exts the ACA before cruise altitude can be reached.*
-
-JSDF-G bases `RJTL` Shimofusa, `RJTE` Tateyama, `RJTK` Kisarazu are not represented as it appears traffic should mostly be military helicopters, which I don't know how to represent in this game.
+JSDF-G bases `RJTE` Tateyama and `RJTK` Kisarazu are not represented as it appears traffic should mostly be military helicopters, which are difficult to represent in this game. JSDF-M base `RJTL` Shimofusa is not currently implemented, but may be in a future version.
 `RJTO` Oshima/`RJAN` Niijima are not represented as traffic is either helicopters or traffic to `RJTF` Chofu in `RJTY` Yokota ACA. Unfortunately traffic to `RJTY` is difficult to represent as `RJTT` ACA has airspace on top of most of `RJTY` ACA, meaning that within the game, it is not possible to get planes to "spawn" from the appropriate region.
 
 ## Airports
@@ -27,12 +23,12 @@ Most fixes visible on the map have a defined hold including many fixes along the
 
 Aircraft arrive at 6 points:
 
-- `SPENS` -`Y71`-> `XAC` (west from western Japan, Korea, Northern China)
-- `SELNO` -`Y21`-> `RUNSO` -`Y21`-> `AKSEL` (south west from southwestern Japan, Okinawa, Southeast Asia)
-- `TOPIT` -`Y875`-> `RURER` -`Y875`-> `AROSA` (south from Hachijojima, Indonesia/Australia)
-- `DOLBA` -`Y824`-> `AROSA` (southeast from oceanic, Australia/NZ/Pacific islands, Guam)
-- `TEDIX` -`Y10`-> `GODIN` (north from northern Japan, Russia, Europe, east NA)
-- `LALID` -`Y807`-> `POLIX` (east from oceanic, west NA/SA, Hawaii)
+- `SPENS` -> `XAC` (west from western Japan, Korea, Northern China)
+- `SELNO` -> `RUNSO` -> `AKSEL` (south west from southwestern Japan, Okinawa, Southeast Asia)
+- `TOPIT` -> `LUTNA` -> `RURER` -> `AROSA` (south from Hachijojima, Indonesia/Australia)
+- `DOLBA` -> `AROSA` (southeast from oceanic, Australia/NZ/Pacific islands, Guam)
+- `TEDIX` -> `GODIN` (north from northern Japan, Russia, Europe, east NA)
+- `LALID` -> `MILIT` -> `RUSDA` -> `ESKEN` -> `POLIX` (east from oceanic, west NA/SA, Hawaii)
 
 Aircraft depart via:
 
@@ -56,33 +52,37 @@ There are four runways:
 - 16L/34R (RWY C)
 - 05/23 (RWY D)
 
-A few different configurations are used in real operations; four are available in this version of RJTT ACA:
+A few different configurations are used in real operations; four are available in this version of `RJTT` ACA:
 
 -	Landing 34L/34R, departing 34R/05
 	
-	In general, arrivals from the southwest (XAC, AKSEL, AROSA) land 34L and arrivals from the northeast (GODIN, POLIX) land 34R. Departures to the northeast takeoff from 34R, and departures to the southwest takeoff from 05 in general.
+	In general, arrivals from the southwest (`XAC`, `AKSEL`, `AROSA`) land 34L and arrivals from the northeast (`GODIN`, `POLIX`) land 34R. Departures to the northeast takeoff from 34R, and departures to the southwest takeoff from 05 in general.
 
 	34L handles the higher amounts of traffic from the southwest, and 05 handles the higher amounts of traffic heading southwest. The lower amounts of traffic to/from the northeast share 34R in mixed operation. 04 is not used in this configuration as it conflicts with landings on 34L (in real life, it may be used for some GA departures?).
 
-	Approaches to 34L (RWY *A*) and 34R (RWY *C*) are available using APP mode from *A*RLON and *C*REAM respectively, with transitions from ARLON or CAMEL depending whether the aircraft is approaching from the south or the east.
+	Approaches to 34L (RWY *A*) and 34R (RWY *C*) are available using APP mode from *A*RLON and *C*REAM respectively, with transitions from `ARLON` or `CAMEL` depending whether the aircraft is approaching from the south or the east.
 
-	STARS are available using APP mode from XAC, RUNSO, AROSA, GODIN, MILIT, and many other intermediate points on the STARs. STARS to 34L/34R implement a point merge system around WEDGE for 34L and CREAM for 34R. Aircraft fly an arc around a point (WEDGE/CREAM), and you can sequence planes by directing planes to proceed direct WEDGE/CREAM and activate APP mode. By default south arrivals fly STARs and approaches to 34L, but you can engage APP mode from CLONE to have planes swing wide of the WEDGE arc to join the CREAM arc for 34R.
+	STARs are available using APP mode from `XAC`, `RUNSO`, `AROSA`, `GODIN`, `MILIT`, and many other intermediate points on the STARs. `STARS` to 34L/34R implement a point merge system around `WEDGE` for 34L and `CREAM` for 34R. Aircraft fly an arc around a point (`WEDGE`/`CREAM`), and you can sequence planes by directing planes to proceed direct `WEDGE`/`CREAM` and activate APP mode. By default south arrivals fly STARs and approaches to 34L, but you can engage APP mode twice to have planes swing wide of the `WEDGE` arc to join the `CREAM` arc for 34R.
 
-	Note that higher arrivals will conflict with lower arrivals when descending from the point merge arc to meet the =8000 restriction at WEDGE. Either descend the lower arrival (watch out for further lower arrivals) or prioritize the lower arrival over the higher arrival. Also watch for AROSA arrivals conflicting with arrivals to RJAA.
+	Note that higher arrivals will conflict with lower arrivals when descending from the point merge arc to meet the =8000 restriction at `WEDGE`. Either descend the lower arrival (watch out for further lower arrivals) or prioritize the lower arrival over the higher arrival. Also watch for `AROSA` arrivals conflicting with arrivals to `RJAA`.
 
-	Note that the normal runway operation for 34L/34R arrivals (HIGHWAY VISUAL 34R and ILS X 34L from KAIHO) is not possible to implement due to the lack of visual approaches in the game and the fact that aircraft joining the parallel ILS above RJTK Kisarazu would conflict as they are at the same altitude. Therefore the approaches depicted are illustrative of IMC conditions necessitating the use of parallel ILS approaches.
+	\***Departures to the west/north/south will need to handed off before they reach the boundary of the ACA**, *as they will likely NOT climb out of the ACA.*\*
+
+	Note that the normal runway operation for 34L/34R arrivals (`HIGHW`AY `VISUA`L 34R and ILS X 34L from `KAIHO`) is not possible to implement due to the lack of visual approaches in the game and the fact that aircraft joining the parallel ILS above `RJTK` Kisarazu would conflict as they are at the same altitude. Therefore the approaches depicted are illustrative of IMC conditions necessitating the use of parallel ILS approaches.
 
 	For an extra challenge, try routing ANA/SNJ/ADO/VIP flights to 34R (T2/VIP area) and JAL/SFJ/SKY/international/GA flights to 34L (T1/T3/N area).
 
 -	Landing 22/23 (ILS), departing 16L/16R
 	
-	In general, arrivals from the southwest (XAC, AKSEL, AROSA) land **\*22\*** and arrivals from the northeast (GODIN, POLIX) land **\*23\***. Departures to the northeast takeoff from 34R, and departures to the southwest takeoff from 05 in general.
+	In general, arrivals from the southwest (`XAC`, `AKSEL`, `AROSA`) land **\*22\*** and arrivals from the northeast (`GODIN`, `POLIX`) land **\*23\***. Departures to the northeast takeoff from 34R, and departures to the southwest takeoff from 05 in general.
 
 	22/16R handles the higher amounts of traffic to/from the southwest as they do not conflict with other runways (16R departures depart before the intersection with 22). As RWY23 arrivals conflict with departures from both 16s, it is used for traffic arriving from the northeast.
 
-	Approaches to 22 and 23 are available using APP mode from NEXUS and SMILE respectively, with transitions from *N*YLON or *S*TEAM depending whether the aircraft is approaching from the *n*orth or the *s*outh.
+	Approaches to 22 and 23 are available using APP mode from `NEXUS` and `SMILE` respectively, with transitions from *N*YLON or *S*TEAM depending whether the aircraft is approaching from the *n*orth or the *s*outh.
 
-	STARS are available using APP mode from XAC, RUNSO, AROSA, GODIN, MILIT, and many other intermediate points on the STARs. STARs from the southwest implement a point merge system around SHAFT (STARs from the northeast are traditional). Aircraft fly an arc around a SHAFT, and you can sequence planes by directing planes to proceed direct SHAFT and activate APP mode. By default south arrivals fly STARs and approaches to 22, but you can engage APP mode from LAFIT to have planes descend under the SHAFT arc to BACON for 23.
+	`STARS` are available using APP mode from `XAC`, `RUNSO`, `AROSA`, `GODIN`, `MILIT`, and many other intermediate points on the STARs. STARs from the southwest implement a point merge system around `SHAFT` (STARs from the northeast are traditional). Aircraft fly an arc around a `SHAFT`, and you can sequence planes by directing planes to proceed direct `SHAFT` and activate APP mode. By default south arrivals fly STARs and approaches to 22, but you can engage APP mode twice to have planes descend under the `SHAFT` arc to `BACON` for 23. Be careful of conflicts with traffic from the north inbound 23.
+
+	\***Departures to the west/north/south will need to handed off before they reach the boundary of the ACA**, *as they will likely NOT climb out of the ACA.*\*
 
 	For an extra challenge, try routing ANA/SNJ/ADO/VIP flights to 23 (T2/VIP area) and JAL/SFJ/SKY/international/GA flights to 22 (T1/T3/N area).
 
@@ -94,7 +94,7 @@ A few different configurations are used in real operations; four are available i
 
 	Approaches to 22 (RWY *B*) and 23 (RWY *D*) are available using APP mode from *B*ONUS and *D*OYLE respectively, with transitions from *B*ACON or *D*ATUM depending whether the aircraft is approaching from the north or the south.
 
-	STARS are available using APP mode from XAC, RUNSO, AROSA, GODIN, MILIT, and many other intermediate points on the STARs. STARs from the southwest implement a point merge system around SHAFT (STARs from the northeast are traditional). Aircraft fly an arc around a SHAFT, and you can sequence planes by directing planes to proceed direct SHAFT and activate APP mode.  By default south arrivals fly STARs and approaches to 22, but you can engage APP mode from LAFIT to have planes descend under the SHAFT arc to BACON for 23.
+	`STARS` are available using APP mode from `XAC`, `RUNSO`, `AROSA`, `GODIN`, `MILIT`, and many other intermediate points on the STARs. STARs from the southwest implement a point merge system around `SHAFT` (STARs from the northeast are traditional). Aircraft fly an arc around a `SHAFT`, and you can sequence planes by directing planes to proceed direct `SHAFT` and activate APP mode.  By default south arrivals fly STARs and approaches to 22, but you can engage APP mode twice to have planes descend under the `SHAFT` arc to `BACON` for 23. Be careful of conflicts with traffic from the north inbound 23.
 
 	\***Departures to the west/north/south will need to handed off before they reach the boundary of the ACA**, *as they will likely NOT climb out of the ACA.*\*
 
@@ -104,11 +104,11 @@ A few different configurations are used in real operations; four are available i
 
 -	Landing 16L/16R, departing 16R/04/16L
 
-	A new approach path flying over central Tokyo only applied in the afternoon hours, which was recently developed in response to growing traffic at RJTT. Normally arrivals fly close parallel RNAV tracks to the final approach course with a 3.45 degree glideslope, however, game limitations mean that parallel arrivals would be conflicting with each other all the way to the final approach fix. Therefore, the "backup" ILS approaches that take a dive into the Yokota ACA have been implemented here.
+	A new approach path flying over central Tokyo only applied in the afternoon hours, which was recently developed in response to growing traffic at `RJTT`. Normally arrivals fly close parallel RNAV tracks to the final approach course with a 3.45 degree glideslope, however, game limitations mean that parallel arrivals would be conflicting with each other all the way to the final approach fix. Therefore, the "backup" ILS approaches that take a dive into the Yokota ACA have been implemented here.
 
-	Approaches to 16L and 16R are available using APP mode from SANDY and NATTY respectively.
+	Approaches to 16L and 16R are available using APP mode from `SANDY` and `NATTY` respectively.
 
-	STARS are available using APP mode from XAC, RUNSO, AROSA, GODIN, MILIT, and many other intermediate points on the STARs. STARS to 16L/16R implement a point merge system around SHAFT for 16L and NEURO for 16R. Aircraft fly an arc around a point (SHAFT/NEURO), and you can sequence planes by directing planes to proceed direct SHAFT/NEURO and activate APP mode. By default south arrivals fly STARs and approaches to 16L, but you can engage APP mode from SCOUT to have planes fly over the SHAFT arc to join the NEURO arc for 16R.
+	`STARS` are available using APP mode from `XAC`, `RUNSO`, `AROSA`, `GODIN`, `MILIT`, and many other intermediate points on the STARs. `STARS` to 16L/16R implement a point merge system around `SHAFT` for 16L and `NEURO` for 16R. Aircraft fly an arc around a point (`SHAFT`/`NEURO`), and you can sequence planes by directing planes to proceed direct `SHAFT`/`NEURO` and activate APP mode. By default south arrivals fly STARs and approaches to 16L, but you can engage APP mode twice to have planes fly over the `SHAFT` arc to join the `NEURO` arc for 16R.
 
 	\***Departures to the west/north/south will need to handed off before they reach the boundary of the ACA**, *as they will likely NOT climb out of the ACA.*\*
 
@@ -116,32 +116,32 @@ A few different configurations are used in real operations; four are available i
 
 	For an extra challenge, try routing ANA/SNJ/ADO/VIP flights to 23 (T2/VIP area) and JAL/SFJ/SKY/international/GA flights to 22 (T1/T3/N area).
 
-### RJAA
+### `RJAA`
 
 The secondary, yet also major airport of this sector. Previously handling almost all of Tokyo's international traffic, it has lost some of it to Haneda recently. However, it still handles a large chunk of Tokyo's international flights as well as the many cargo flights from FDX/UPS etc. RWY 34R which was too short when Narita opened to handle heavy aircraft has now been extended and can generally handle most aircraft other than the largest of aircraft such as A388.
 
-There is custom traffic for RJAA. The proportions are very much estimates but shouldn't be too far off from reality.
+There is custom traffic for `RJAA`. The proportions are very much estimates but shouldn't be too far off from reality.
 
-Most fixes visible on the map have a defined hold including many fixes along the STARs. The published hold for missed approaches is SWIMY for 16R/34L and ABBOT for 16L/34R.
+Most fixes visible on the map have a defined hold including many fixes along the STARs. The published hold for missed approaches is `SWIMY` for 16R/34L and `ABBOT` for 16L/34R.
 
 Aircraft arrive at 4 points:
 
-- `BAFFY` -`Y81`-> `RUTAS` (southwest from western and southwestern)
-- `VAGLA` -`Y813`-> `LUBLA` (northeast oceanic)
-- `LESPO` -`Y809`-> `SUPOK` (southeast oceanic)
-- `GURIR` -`Y30`-> `SWAMP` (north from north, northwest and northeast)
+- `BAFFY` -> `MAMAS` -> `RUTAS` (southwest from western and southwestern)
+- `VAGLA` -> `LUBLA` (northeast oceanic)
+- `LESPO` -> `SUPOK` (southeast oceanic)
+- `GURIR` -> `SWAMP` (north from north, northwest and northeast)
 
 Aircraft depart via:
 
-- `AGRIS` (northwest via `TETRA8` departure `AGRIS` transition to `Y37`)
-- `KIMIN` (north via `TETRA8` departure `KIMIN` transition to `Y117`)
-- `GULBO` (northeast oceanic via `GULBO2` departure to `Y808`)
-- `BORLO` (east oceanic via `BORLO2` departure to `Y830`)
-- `IRNOK` (southsoutheast oceanic via `OLVAN2` departure to `Y823`)
-- `NORIS` (south oceanic via `OLVAN2` departure `SAMUS` transition to `Y84`)
-- `SEDRI` (southwest via `PIGOK2` departure to `Y50`)
-- `MITOP` (west via `REDEK2` departure to `Y60`)
-- `TEPEX` (northwest via `TETRA8` departure `ENPAR` transition to `Y16`)
+- `AGRIS` (northwest)
+- `KIMIN` (north)
+- `GULBO` (northeast oceanic)
+- `BORLO` (east oceanic)
+- `IRNOK` (southsoutheast oceanic)
+- `NORIS` (south oceanic)
+- `SEDRI` (southwest)
+- `MITOP` (west)
+- `TEPEX` (northwest)
 
 There are two runways:
 
@@ -154,44 +154,44 @@ There are two simple runway configurations:
 
 	Approaches to 34L and 34R are available using APP mode from `GIINA` and `TEMIS` respectively, with transitions from `TYLER` or `ELGAR` depending whether the aircraft is approaching from the south or the east.
 
-	STARS are available using APP mode from `BAFFY`, SWAMP, SUPOK, LUBLA, and many other intermediate points on the STARs. STARS to 34L implement a point merge system around PEAKS. Aircraft fly an arc around PEAKS, and you can sequence planes by directing planes to proceed direct PEAKS and activate APP mode. Alternate STARs are available to 34R which do not implement a point merge arc; watch out for potential conflicts with arrivals on STARs to 34L.
+	`STARS` are available using APP mode from `BAFFY`, `SWAMP`, `SUPOK`, `LUBLA`, and many other intermediate points on the STARs. STARs to 34L implement a point merge system around `PEAKS`. Aircraft fly an arc around `PEAKS`, and you can sequence planes by directing planes to proceed direct `PEAKS` and activate APP mode. Alternate STARs are available to 34R which do not implement a point merge arc; watch out for potential conflicts with arrivals on STARs to 34L.
 
-	Note that higher altitude arrivals on the arc will conflict with lower altitude arrivals descending from the point merge arc to meet the =6000 restriction at PEAKS. Either descend the lower altitude arrival (watch out for even lower altitude arrivals) or prioritize the lower altitude arrival over the higher altitude arrival.
+	Note that higher altitude arrivals on the arc will conflict with lower altitude arrivals descending from the point merge arc to meet the =6000 restriction at `PEAKS`. Either descend the lower altitude arrival (watch out for even lower altitude arrivals) or prioritize the lower altitude arrival over the higher altitude arrival.
 
-	For arrivals from RUTAS, watch out for conflicts with AROSA arrivals to RJTT.
+	For arrivals from `RUTAS`, watch out for conflicts with `AROSA` arrivals to `RJTT`.
 
-	Departures are executed in parallel and maintain horizontal separation until east of RJAA. Recommend not assigning higher than 7000 to 34L departures until clear of RJTT arrivals from GODIN/POLIX.
+	Departures are executed in parallel and maintain horizontal separation until east of `RJAA`. Recommend not assigning higher than 7000 to 34L departures until clear of `RJTT` arrivals from `GODIN`/`POLIX`.
 
 	For an extra challenge, try routing oneworld/LCC flights to 34R (T2/T3) and other flights to 34L (T1/cargo area).
 
 -	Landing 22/23, departing 16L/16R
 
-	Approaches to 16L and 16R are available using APP mode from MARCH and ACELA respectively, with transitions from TYLER or ELGAR depending whether the aircraft is approaching from the south or the east.
+	Approaches to 16L and 16R are available using APP mode from `MARCH` and `ACELA` respectively, with transitions from `TYLER` or `ELGAR` depending whether the aircraft is approaching from the south or the east.
 
-	STARS are available using APP mode from BAFFY, SWAMP, SUPOK, LUBLA, and many other intermediate points on the STARs. STARS to 16R implement a point merge system around CASIO. Aircraft fly an arc around CASIO, and you can sequence planes by directing planes to proceed direct CASIO and activate APP mode.  Alternate STARs are available to 16L which do not implement a point merge arc; watch out for potential conflicts with arrivals on STARs to 16R.
+	`STARS` are available using APP mode from `BAFFY`, `SWAMP`, `SUPOK`, `LUBLA`, and many other intermediate points on the STARs. `STARS` to 16R implement a point merge system around `CASIO`. Aircraft fly an arc around `CASIO`, and you can sequence planes by directing planes to proceed direct `CASIO` and activate APP mode.  Alternate STARs are available to 16L which do not implement a point merge arc; watch out for potential conflicts with arrivals on STARs to 16R.
 
-	Note that higher altitude arrivals on the arc will conflict with lower altitude arrivals descending from the point merge arc to meet the =6000 restriction at CASIO. Either descend the lower altitude arrival (watch out for even lower altitude arrivals) or prioritize the lower altitude arrival over the higher altitude arrival.
+	Note that higher altitude arrivals on the arc will conflict with lower altitude arrivals descending from the point merge arc to meet the =6000 restriction at `CASIO`. Either descend the lower altitude arrival (watch out for even lower altitude arrivals) or prioritize the lower altitude arrival over the higher altitude arrival.
 
-	Use care not to descend arrivals into RJAH/RJAK airspace.
+	Use care not to descend arrivals into `RJAH`/`RJAK` airspace.
 
 	For an extra challenge, try routing oneworld/LCC flights to 16L (T2/T3) and other flights to 16R (T1/cargo area).
 
 ## Known Issues
 
-- RJTT LDA approaches aren't really LDA approaches with the VPT (visual prescribed track), just a hack ILS approach to a fictional runway.
-- No RJTT RNAV 16L/16R due to game limitations (conflicts between parallel arrivals on RNAV track).
+- `RJTT` LDA approaches aren't really LDA approaches with the VPT (visual prescribed track), just a hack ILS approach to a fictional runway.
+- No `RJTT` RNAV 16L/16R due to game limitations (conflicts between parallel arrivals on RNAV track).
 - No fair weather 34L/34R approach usage (no visual approaches, conflict on joining parallel ILS at same altitude)
-- No RJTO Oshima/RJAN Niijima (not possible to model arrivals from RJTY ACA)
-- SELNO arrivals can spawn a bit inside the ACA with no warning.
+- No `RJTO` Oshima/`RJAN` Niijima (not possible to model arrivals from `RJTY` ACA)
+- `SELNO` arrivals can spawn a bit inside the ACA with no warning.
 - Arrival and departure directions can be a bit nonsense (e.g. AHK arriving from the Pacific), unfortunately this is a game limitation.
-- South arrivals to RJTT 16L/16R are very close to delayed even strictly following the STAR (game limitation?)
-- `RJTT` `GODIN`/`POLIX` `2A` arrivals not implemented (is there a use case given they go through the `CREAM` point merge, and the ILS Z RWY 34L approach has an )
+- South arrivals to `RJTT` 16L/16R are very close to delayed even strictly following the STAR (game limitation?)
+- `SWAMP`/`SUPOK`/`LUBLA` arrivals prioritize 34R/16L
 
 ## Changelog
 
 *	1.0 - 2020/10/19 - Initial version.
 *	1.1 - 2020/10/19
-	- Add RJAA.
+	- Add `RJAA`.
 	- bug fixes
 *	1.2 - 2020/10/23
 	- Flesh out airspace (`RJTT`/`RJAA` CTR/PCA, airspace over `RJAH`/`RJTY`/`RJTU` ACA, `RJTL`/`RJTE`/`RJTK` CTR)
@@ -205,19 +205,19 @@ There are two simple runway configurations:
 	- Fix approaches from `GIINA`, `TEMIS`, `ACELA`, `MARCH` to actually work
 	- Add case for approach from `NOVEL` when already south of `NOVEL`
 *	1.3 - 2020/10/24
-	- Extend RJTT `LAXAS` SID to `KAGNA`
-	- Shorten RJTT `ROVER` SID `AKAGI` transition to the exit point from the ACA, `CLARK`
-	- Add RJTT `VAMOS` SID `XAC` transition to `B586`
+	- Extend `RJTT` `LAXAS` SID to `KAGNA`
+	- Shorten `RJTT` `ROVER` SID `AKAGI` transition to the exit point from the ACA, `CLARK`
+	- Add `RJTT` `VAMOS` SID `XAC` transition to `B586`
 	- Adjusted entry points
-	- Adjust label for `RJTL` Shimofusa CTR
+	- Adjust label for Shimofusa CTR
 	- Add readme
 *	1.3.1 - 2020/10/25
-	- Correct `CCA` callsign pronunciation for `RJAA`
+	- Correct CCA callsign pronunciation for `RJAA`
 *	2.0.0 - 2020/11/02
 	- Add approaches to many, many fixes as the approach limit has been lifted.
 	- Add `RJTT` 16L/16R ILS approaches
-	- Add `RJTT` 22/23 "LDA" approaches
-	- `RJAA` arrivals now fly direct to first point inside `RJTT` ACA on their arrival route instead of `NRE`.
+	- Add `RJTT` "LDA" 22/23 approaches
+	- `RJAA` arrivals now fly direct to first point inside `RJTT` ACA on their arrival route instead of NRE.
 	- Adjusted entry points
 	- Added missing `ALDEN` waypoint for some STARs from `AROSA`
 	- Adjusted traffic frequencies
@@ -225,11 +225,8 @@ There are two simple runway configurations:
 *	2.0.1 - 2020/11/02
 	- Fix aircraft failing to intercept the localizer for LDA approaches by changing name of runway
 *	2.0.2 - 2020/11/02
-	- Add `CAMEL` fix as IF for 34R and appropriate transitions. Now `CREAM` is no longer both the point merge fix and initial approach fix for 34R, and aircraft can shortcut from `2C` arrivals direct to `CREAM` and fly the 34R approach via `CREAM` transition.
-*	2.0.3 - 2020/11/10
-	- Fix `HDJT` max speed
-	- Add `GUMYO` as minor fix (intermediate fix to SWIMY on 16R/34L missed approaches)
-*	2.1.0 - 2020/11/10
-	- Add RJTT `XAC`/`AKSEL`/`AROSA` `2C` STARs to 34R via the `CREAM` point merge and `2N`, `2B` STARs under the `SHAFT` point merge to 23 to all fixes shared with other STARs
-	- Add RJAA `E`/`N` STARs to all fixes shared with other STARs
-	- Approaches now available from `BACON`, `DATUM`, `STEAM`, `NYLON`, `ELGAR`, `NORMA` IAFs.
+	- Add `CAMEL` fix as IF for 34R and appropriate transitions. Now `CREAM` is no longer both the point merge fix and initial approach fix for 34R, and aircraft can shortcut from 2C arrivals direct to `CREAM` and fly the 34R approach via `CREAM` transition.
+*	2.1.0 - 2020/11/12
+	- Fix 34R approach from `ARLON`
+	- Fix erroneous coordinates for `POLIX` in `POLIX1S` arrival
+	- Prioritize 16L/34R at `RJAA` instead of 16R/34L for approaches. PMS STARs now lead to 16L/34R via `GEMIN` and `TYLER`, the alternative STARs now lead to 16R/34L via 'NORMA' and 'ELGAR'. This should be more reflective of actual runway use.


### PR DESCRIPTION
*	2.1.0 - 2020/11/12
	- Fix 34R approach from `ARLON`
	- Fix erroneous coordinates for `POLIX` in `POLIX1S` arrival
	- Prioritize 16L/34R at `RJAA` instead of 16R/34L for approaches. PMS STARs now lead to 16L/34R via `GEMIN` and `TYLER`, the alternative STARs now lead to 16R/34L via `NORMA` and `ELGAR`. This should be more reflective of actual runway use.